### PR TITLE
Generate page based on Facebook posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .sass-cache
 build/
+data/facebook_posts.json

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: build
-build:
+build: fetch-facebook
 	bundle exec middleman build -e production
 
 .PHONY: build-staging
-build-staging:
+build-staging: fetch-facebook
 	bundle exec middleman build -e staging
 
 .PHONY: serve
-serve:
+serve: fetch-facebook
 	bundle exec middleman serve
 
 .PHONY: deploy
@@ -21,3 +21,7 @@ stage: build-staging
 .PHONY: clean
 clean:
 	rm -Rf build/
+
+.PHONY: fetch-facebook
+fetch-facebook:
+	bin/fetch-facebook-posts

--- a/bin/fetch-facebook-posts
+++ b/bin/fetch-facebook-posts
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function main() {
+  inflight_json=$(mktemp -d "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+  echo Saving files to $inflight_json
+
+  # Grab all the pages
+  local i=0
+  local next_page_url="https://graph.facebook.com/v7.0/dannahforcitycouncil/posts?fields=message,created_time,attachments\{type,url,description,media,media_type\},status_type,story,is_published,permalink_url&limit=25&access_token=$FACEBOOK_API_TOKEN" 
+  while true;
+  do
+    ((++i))
+    local page_path=$inflight_json/page-$i.json
+    echo Downloading page $i to $page_path
+    echo Using URL $next_page_url
+    curl -Ss -XGET $next_page_url > $page_path
+    next_page_url=$(jq --raw-output .paging.next < $page_path)
+    echo "Next page is $next_page_url"
+    if [[ $next_page_url = "null" ]]; then
+      echo "All done! No more pages."
+      break
+    else
+      Echo Continuing on…
+    fi
+  done
+  echo "All done downloading!"
+
+  # Combine into one ur-json and filter out stuff we don't want
+	jq -s '[.[].data | map(select(has("message")))] | flatten' $inflight_json/*.json > data/facebook_posts.json
+}
+
+main $*

--- a/config.rb
+++ b/config.rb
@@ -57,6 +57,18 @@ helpers do
       resource.data.order
     end
   end
+
+  def render_markdown(input)
+    Kramdown::Document.new(input).to_html
+  end
+
+  def excerpt_facebook_post(input)
+    first, *rest = input.split(/\n\n/)
+    [
+      truncate_words(first, length: 64, omission: "…"),
+      (link_to("See more", "#") if rest.any?),
+    ].compact.join(" ")
+  end
 end
 
 # Build-specific configuration

--- a/data/contact.yml
+++ b/data/contact.yml
@@ -1,10 +1,10 @@
 email: dannahthompsonforcitycouncil@gmail.com
 paypal: https://paypal.me/thompsonforcouncil
 phone: (763) 438-6572
-facebook: https://www.facebook.com/Dannah-Thompson-for-Roseville-City-Council-430548354038194/
+facebook: https://www.facebook.com/DannahForCityCouncil/
 twitter_handle: DannahThompson
 address:
   lines:
     - Dannah Thompson for City Council
-    - 2425 County Rd. C2 West #312
+    - 2425 County Rd. C2 West \#312
     - Roseville, MN 55113

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -11,13 +11,14 @@
     <%= stylesheet_link_tag "site" %>
     <%# javascript_include_tag "site" %>
   </head>
-  <body>
+  <body class="<%= page_classes %>">
     <header>
       <nav>
         <h1>Dannah Thompson for Roseville City Council</h1>
         <ul>
           <%= wrapped_nav_link_to title: "My Vision for Roseville", url: "/index.html" %>
           <%= wrapped_nav_link_to title: "Issues", url: "/issues.html" %>
+          <%= wrapped_nav_link_to title: "Statements", url: "/posts.html" %>
           <%= wrapped_nav_link_to title: "Contact & Media", url: "/contact.html" %>
           <%= wrapped_nav_link_to title: "Volunteer & Donate", url: "/volunteer-donate.html" %>
         </ul>

--- a/source/posts.html.markdown.erb
+++ b/source/posts.html.markdown.erb
@@ -1,0 +1,32 @@
+---
+description: Dannah's thoughts on current events.
+title: Statements from Dannah
+---
+
+<% data.facebook_posts.each do |post| %>
+  <article class="post-summary" id="post-<%= post.id %>">
+    <h3>
+      Originally <%= link_to "posted on Facebook", post.permalink_url %>
+      <time datetime="<%= post.created_time %>"><%= Date.parse(post.created_time).strftime("%A, %-d %B %Y") %></time>
+      <a href="#post-<%= post.id %>" class="post-anchor" title="Permalink to this statement">#</a>
+    </h3>
+    <% (post.attachments&.data || []).each do |attachment| %>
+      <p class="media">
+      <a href="<%= attachment.url %>">
+        <% case attachment.media_type %>
+        <% when "video" %>
+          Watch the video!
+        <% else %>
+          <% if attachment.media&.image %>
+            <%= image_tag attachment.media.image.src,
+              alt: attachment.description %>
+          <% else %>
+            <blockquote><%= attachment.description %></blockquote>
+          <% end %>
+        <% end %>
+      </a>
+      </p>
+    <% end %>
+    <%= render_markdown(post.message) %>
+  </article>
+<% end %>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -124,7 +124,7 @@ ul.issues {
   }
 }
 
-blockquote {
+body.index blockquote {
   background: $brand_medium;
   border-radius: 5px;
   clear: both;
@@ -172,5 +172,55 @@ footer {
 @include on-mobile {
   header, main, footer {
     padding: 0 0.5rem;
+  }
+}
+
+.post-summary {
+  h3 {
+    position: relative;
+
+    @include on-mobile {
+      time {
+        display: block;
+      }
+
+      .post-anchor {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+      }
+    }
+
+    @include off-mobile {
+      .post-anchor {
+        visibility: hidden;
+      }
+
+      &:hover .post-anchor {
+        visibility: visible;
+      }
+    }
+  }
+
+  .media {
+    margin: 1rem 0;
+
+    img {
+      width: 100%;
+    }
+  }
+
+  blockquote {
+    border-left: 3px solid $brand_medium;
+    margin: 0;
+    padding: 0 1rem;
+
+    a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }


### PR DESCRIPTION
Because:

* Dannah posts to Facebook and we'd like to keep doing that
* But we'd also like a campaign page with her words, so she doesn't have to link to Facebook to share her thoughts

Solution:

* Cross-post to the campaign site upon posting to Facebook
* Fetch Facebook posts with their API and combine into a JSON file in data/
* Generate a page based on those posts
* Format accordingly

TODOs:

* [x] Verify `jq` can/will work on Netlify for fetching posts
* [x] Deploy to staging and make sure we're happy
* [x] Link to Facebook in the title; include permalink-on-hover anchor to link to specific posts on the site
* [x] Trigger staging and production deploys from new Facebook posts