### PR TITLE
Read Google Analytics key from environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: build
 build: fetch-facebook
-	bundle exec middleman build -e production
+	bundle exec middleman build
 
 .PHONY: build-staging
 build-staging: fetch-facebook
-	bundle exec middleman build -e staging
+	bundle exec middleman build
 
 .PHONY: serve
 serve: fetch-facebook

--- a/config.rb
+++ b/config.rb
@@ -82,11 +82,3 @@ configure :build do
   activate :minify_css
   activate :minify_javascript
 end
-
-configure :staging do
-  config[:google_analytics_key] = "UA-151307154-1"
-end
-
-configure :production do
-  config[:google_analytics_key] = "UA-151307154-2"
-end

--- a/source/_google_analytics.html.erb
+++ b/source/_google_analytics.html.erb
@@ -5,6 +5,6 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '<%= config[:google_analytics_key] %>');
+  gtag('config', '<%= ENV.fetch("GOOGLE_ANALYTICS_KEY", "TK") %>');
 </script>
 


### PR DESCRIPTION
Because:

* Lets me simplify back to a single deploy environment

Solution:

* Remove the different stages from configuration
* Read the GA key from analytics instead of Middleman environment-specific configuration