### PR TITLE
Add og: unfurling metadata to the pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -32,6 +32,18 @@ page '/*.txt', layout: false
 # https://middlemanapp.com/basics/helper-methods/
 
 helpers do
+  def site_name
+    "Dannah Thompson for Roseville City Council"
+  end
+
+  def page_title(page = current_page)
+    [page.data.title, page.data.section, site_name].compact.join(" | ")
+  end
+
+  def page_description(page = current_page)
+    page.data.description || page.data.excerpt || "Campaign website for #{site_name}"
+  end
+
   def current_url?(url)
     url == "/#{current_page.path}"
   end

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,9 +5,14 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <%= tag :meta, name: "description", content: current_page.data.description || current_page.data.excerpt || "Campaign website for Dannah Thompson for Roseville City Council"%>
+    <%= tag :meta, name: "description", content: page_description %>
     <!-- Use the title from a page's frontmatter if it has one -->
-    <title><%= [current_page.data.title, current_page.data.section, "Dannah Thompson for Roseville City Council"].compact.join(" | ") %></title>
+    <title><%= page_title %></title>
+    <%= tag :meta, property: "og:url", content: current_page.url %>
+    <%= tag :meta, property: "og:title", content: page_title %>
+    <%= tag :meta, property: "og:description", content: page_description %>
+    <%= tag :meta, property: "og:site_name", content: site_name %>
+    <%= tag :meta, property: "og:image", content: "#{ENV["URL"]}#{image_path("dannah-portrait.jpg")}" %>
     <%= stylesheet_link_tag "site" %>
     <%# javascript_include_tag "site" %>
   </head>


### PR DESCRIPTION
Because:

* Google and Twitter and Facebook and Slack and others can use it to intelligently display additional information for pasted links.

Solution:

* Add them to the `head`